### PR TITLE
Add Homebrew and krew release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,17 +11,17 @@ jobs:
           curl -L -o ~/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.14.0/bin/linux/amd64/kubectl
           chmod +x ~/bin/kubectl
       - run: |
-          curl -L -o ~/bin/ghcp https://github.com/int128/ghcp/releases/download/v1.3.0/ghcp_linux_amd64
-          chmod +x ~/bin/ghcp
-      - run: |
           curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b ~/bin v1.16.0
-      - run: go get github.com/int128/goxzst
       - checkout
       - run: make check
       - run: bash <(curl -s https://codecov.io/bash)
       - run: make run
       - run: |
           if [ "$CIRCLE_TAG" ]; then
+            go get github.com/int128/goxzst
+            go get github.com/tcnksm/ghr
+            curl -L -o ~/bin/ghcp https://github.com/int128/ghcp/releases/download/v1.5.0/ghcp_linux_amd64
+            chmod +x ~/bin/ghcp
             make release
           fi
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
-TARGET := kubectl-auth_proxy
+TARGET := kauthproxy
+TARGET_PLUGIN := kubectl-auth_proxy
 CIRCLE_TAG ?= HEAD
 LDFLAGS := -X main.version=$(CIRCLE_TAG)
 
-.PHONY: check run release clean
-
+.PHONY: all
 all: $(TARGET)
 
+.PHONY: check
 check:
 	golangci-lint run
 	go test -v -race -cover -coverprofile=coverage.out ./...
@@ -13,17 +14,28 @@ check:
 $(TARGET): $(wildcard *.go)
 	go build -o $@ -ldflags "$(LDFLAGS)"
 
-run: $(TARGET)
+$(TARGET_PLUGIN): $(TARGET)
+	ln -sf $(TARGET) $@
+
+.PHONY: run
+run: $(TARGET_PLUGIN)
 	PATH=.:$(PATH) kubectl auth-proxy --help
 
 dist:
 	VERSION=$(CIRCLE_TAG) goxzst -d dist/gh/ -o "$(TARGET)" -t "kauthproxy.rb auth-proxy.yaml" -- -ldflags "$(LDFLAGS)"
 	mv dist/gh/kauthproxy.rb dist/
+	mkdir -p dist/plugins
+	cp dist/gh/auth-proxy.yaml dist/plugins/auth-proxy.yaml
 
+.PHONY: release
 release: dist
 	ghr -u "$(CIRCLE_PROJECT_USERNAME)" -r "$(CIRCLE_PROJECT_REPONAME)" "$(CIRCLE_TAG)" dist/gh/
-	ghcp -u "$(CIRCLE_PROJECT_USERNAME)" -r "homebrew-$(CIRCLE_PROJECT_REPONAME)" -m "$(CIRCLE_TAG)" -C dist/ kauthproxy.rb
+	ghcp commit -u "$(CIRCLE_PROJECT_USERNAME)" -r "homebrew-$(CIRCLE_PROJECT_REPONAME)" -m "$(CIRCLE_TAG)" -C dist/ kauthproxy.rb
+	ghcp fork-commit -u kubernetes-sigs -r krew-index -b "auth-proxy-$(CIRCLE_TAG)" -m "Bump auth-proxy to $(CIRCLE_TAG)" -C dist/ plugins/auth-proxy.yaml
 
+.PHONY: clean
 clean:
 	-rm $(TARGET)
+	-rm $(TARGET_PLUGIN)
 	-rm -r dist/
+	-rm coverage.out

--- a/auth-proxy.yaml
+++ b/auth-proxy.yaml
@@ -1,0 +1,47 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: auth-proxy
+spec:
+  homepage: https://github.com/int128/kauthproxy
+  shortDescription: Forward a local port to a pod or service via authentication proxy
+  description: |
+    This is a kubectl plugin to forward a local port to a pod or service via authentication proxy.
+    It gets a token from the credential plugin and injects the token to the Authorization header of proxy requests.
+
+  caveats: |
+    You need to configure authentication in the kubeconfig.
+    See https://github.com/int128/kauthproxy for more.
+
+  version: {{ env "VERSION" }}
+  platforms:
+    - uri: https://github.com/int128/kauthproxy/releases/download/{{ env "VERSION" }}/kauthproxy_linux_amd64.zip
+      sha256: "{{ sha256 .linux_amd64_archive }}"
+      bin: kauthproxy
+      files:
+        - from: "kauthproxy"
+          to: "."
+      selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+    - uri: https://github.com/int128/kauthproxy/releases/download/{{ env "VERSION" }}/kauthproxy_darwin_amd64.zip
+      sha256: "{{ sha256 .darwin_amd64_archive }}"
+      bin: kauthproxy
+      files:
+        - from: "kauthproxy"
+          to: "."
+      selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+    - uri: https://github.com/int128/kauthproxy/releases/download/{{ env "VERSION" }}/kauthproxy_windows_amd64.zip
+      sha256: "{{ sha256 .windows_amd64_archive }}"
+      bin: kauthproxy.exe
+      files:
+        - from: "kauthproxy.exe"
+          to: "."
+      selector:
+        matchLabels:
+          os: windows
+          arch: amd64

--- a/kauthproxy.rb
+++ b/kauthproxy.rb
@@ -1,0 +1,15 @@
+class Kauthproxy < Formula
+  desc "A kubectl plugin to forward a local port to a pod or service via authentication proxy"
+  homepage "https://github.com/int128/kauthproxy"
+  url "https://github.com/int128/kauthproxy/releases/download/{{ env "VERSION" }}/kauthproxy_darwin_amd64.zip"
+  version "{{ env "VERSION" }}"
+  sha256 "{{ sha256 .darwin_amd64_archive }}"
+  def install
+    bin.install "kauthproxy" => "kauthproxy"
+    ln_s bin/"kauthproxy", bin/"kubectl-auth_proxy"
+  end
+  test do
+    system "#{bin}/kauthproxy -h"
+    system "#{bin}/kubectl-auth_proxy -h"
+  end
+end


### PR DESCRIPTION
This will release it to [homebrew-kauthproxy](https://github.com/int128/homebrew-kauthproxy) and [krew-index](https://github.com/kubernetes-sigs/krew-index).