### PR TITLE
Remove deprecated selfLink dependency

### DIFF
--- a/pkg/authproxy/auth_proxy.go
+++ b/pkg/authproxy/auth_proxy.go
@@ -82,7 +82,8 @@ func (u *AuthProxy) Do(ctx context.Context, o Option) error {
 		portForwarderOption: portforwarder.Option{
 			Config:              o.Config,
 			SourcePort:          transitPort,
-			TargetPodURL:        pod.GetSelfLink(),
+			TargetNamespace:     pod.Namespace,
+			TargetPodName:       pod.Name,
 			TargetContainerPort: containerPort,
 		},
 		reverseProxyOption: reverseproxy.Option{

--- a/pkg/authproxy/auth_proxy_test.go
+++ b/pkg/authproxy/auth_proxy_test.go
@@ -40,10 +40,10 @@ func newTransport(t *testing.T) transport.NewFunc {
 func TestAuthProxy_Do(t *testing.T) {
 	const containerPort = 18888
 	const transitPort = 28888
-	const podURL = "/api/v1/namespaces/kube-system/pods/kubernetes-dashboard-xxxxxxxx-xxxxxxxx"
 	pod := &v1.Pod{
 		ObjectMeta: v1meta.ObjectMeta{
-			SelfLink: podURL,
+			Name:      "kubernetes-dashboard-12345678-12345678",
+			Namespace: "kubernetes-dashboard",
 		},
 	}
 
@@ -83,7 +83,8 @@ func TestAuthProxy_Do(t *testing.T) {
 				Run(portforwarder.Option{
 					Config:              &restConfig,
 					SourcePort:          transitPort,
-					TargetPodURL:        podURL,
+					TargetNamespace:     "kubernetes-dashboard",
+					TargetPodName:       "kubernetes-dashboard-12345678-12345678",
 					TargetContainerPort: containerPort,
 				}, notNil, notNil).
 				DoAndReturn(func(o portforwarder.Option, readyChan chan struct{}, stopChan <-chan struct{}) error {
@@ -147,7 +148,8 @@ func TestAuthProxy_Do(t *testing.T) {
 				Run(portforwarder.Option{
 					Config:              &restConfig,
 					SourcePort:          transitPort,
-					TargetPodURL:        podURL,
+					TargetNamespace:     "kubernetes-dashboard",
+					TargetPodName:       "kubernetes-dashboard-12345678-12345678",
 					TargetContainerPort: containerPort,
 				}, notNil, notNil).
 				DoAndReturn(func(o portforwarder.Option, readyChan chan struct{}, stopChan <-chan struct{}) error {
@@ -186,7 +188,8 @@ func TestAuthProxy_Do(t *testing.T) {
 				Run(portforwarder.Option{
 					Config:              &restConfig,
 					SourcePort:          transitPort,
-					TargetPodURL:        podURL,
+					TargetNamespace:     "kubernetes-dashboard",
+					TargetPodName:       "kubernetes-dashboard-12345678-12345678",
 					TargetContainerPort: containerPort,
 				}, notNil, notNil).
 				DoAndReturn(func(o portforwarder.Option, readyChan chan struct{}, stopChan <-chan struct{}) error {
@@ -249,7 +252,8 @@ func TestAuthProxy_Do(t *testing.T) {
 				Run(portforwarder.Option{
 					Config:              &restConfig,
 					SourcePort:          transitPort,
-					TargetPodURL:        podURL,
+					TargetNamespace:     "kubernetes-dashboard",
+					TargetPodName:       "kubernetes-dashboard-12345678-12345678",
 					TargetContainerPort: containerPort,
 				}, notNil, notNil).
 				DoAndReturn(func(o portforwarder.Option, readyChan chan struct{}, stopChan <-chan struct{}) error {
@@ -340,7 +344,8 @@ func TestAuthProxy_Do(t *testing.T) {
 				Run(portforwarder.Option{
 					Config:              &restConfig,
 					SourcePort:          transitPort,
-					TargetPodURL:        podURL,
+					TargetNamespace:     "kubernetes-dashboard",
+					TargetPodName:       "kubernetes-dashboard-12345678-12345678",
 					TargetContainerPort: containerPort,
 				}, notNil, notNil).
 				DoAndReturn(func(o portforwarder.Option, readyChan chan struct{}, stopChan <-chan struct{}) error {

--- a/pkg/portforwarder/port_forwarder.go
+++ b/pkg/portforwarder/port_forwarder.go
@@ -25,7 +25,8 @@ var Set = wire.NewSet(
 type Option struct {
 	Config              *rest.Config
 	SourcePort          int
-	TargetPodURL        string
+	TargetNamespace     string
+	TargetPodName       string
 	TargetContainerPort int
 }
 
@@ -44,7 +45,7 @@ type PortForwarder struct {
 // It will close the readyChan when the port forwarder is ready.
 // Caller can stop the port forwarder by closing the stopChan.
 func (pf *PortForwarder) Run(o Option, readyChan chan struct{}, stopChan <-chan struct{}) error {
-	pfURL, err := url.Parse(o.Config.Host + o.TargetPodURL + "/portforward")
+	pfURL, err := url.Parse(fmt.Sprintf("%s/api/v1/namespaces/%s/pods/%s/portforward", o.Config.Host, o.TargetNamespace, o.TargetPodName))
 	if err != nil {
 		return xerrors.Errorf("could not build URL for portforward: %w", err)
 	}


### PR DESCRIPTION
This will remove dependency of deprecated `selfLink` field which will be removed in Kubernetes v1.20.0. Fix #89.