### PR TITLE
Allow all auth plugins of client-go

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,7 @@ cloud.google.com/go v0.72.0/go.mod h1:M+5Vjvlc2wnp6tjzE102Dw08nGShTscUx2nZMufOKP
 cloud.google.com/go v0.74.0/go.mod h1:VV1xSbzvo+9QJOxLDaJfTjx5e+MePCpCWwvftOeQmWk=
 cloud.google.com/go v0.78.0/go.mod h1:QjdrLG0uq+YwhjoVOLsS1t7TW8fs36kLs4XO5R5ECHg=
 cloud.google.com/go v0.79.0/go.mod h1:3bzgcEeQlzbuEAYu4mrWhKqWjmpprinYgKJLgKHnbb8=
+cloud.google.com/go v0.81.0 h1:at8Tk2zUz63cLPR0JPWm5vp77pEZmzxEQBEfRKn1VV8=
 cloud.google.com/go v0.81.0/go.mod h1:mk/AM35KwGk/Nm2YSeZbxXdrNK3KZOYHmLkOqC2V6E0=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=

--- a/main.go
+++ b/main.go
@@ -7,8 +7,7 @@ import (
 
 	"github.com/int128/kauthproxy/pkg/di"
 
-	// for an AKS cluster integrated with Azure AD
-	_ "k8s.io/client-go/plugin/pkg/client/auth/azure"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 var version = "v0.0.0"


### PR DESCRIPTION
I'd like to use kauthproxy with OIDC, but it'not allowed.

Importing `k8s.io/client-go/plugin/pkg/client/auth` lets us to use all plugins: oidc, azure, gcp, openstack.
cf. https://github.com/kubernetes/client-go/tree/master/plugin/pkg/client/auth

Thanks.