### PR TITLE
Fix e2e-test for Kubernetes 1.24+

### DIFF
--- a/e2e_test/Makefile
+++ b/e2e_test/Makefile
@@ -15,7 +15,7 @@ deploy: cluster
 	kustomize build | kubectl apply -f -
 	kubectl -n kube-system rollout status deployment metrics-server
 	kubectl -n kubernetes-dashboard rollout status deployment kubernetes-dashboard
-	kubectl get serviceaccount tester '-ojsonpath={.secrets[0].name}' | xargs kubectl get secret '-ojsonpath={.data.token}' | base64 --decode | xargs kubectl config set-credentials tester --token
+	kubectl get secret tester-token '-ojsonpath={.data.token}' | base64 --decode | xargs kubectl config set-credentials tester --token
 
 output/kauthproxy:
 	go build -o $@ ..

--- a/e2e_test/kauthproxy-role.yaml
+++ b/e2e_test/kauthproxy-role.yaml
@@ -24,6 +24,15 @@ metadata:
   name: tester
 
 ---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: tester-token
+  annotations:
+    kubernetes.io/service-account.name: tester
+
+---
 # allow kauthproxy access
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Since Kubernetes 1.24, a token of service account is not automatically created.
https://stackoverflow.com/questions/72256006/service-account-secret-is-not-listed-how-to-fix-it